### PR TITLE
fixed the broken /4W/texts links that should point at /texts

### DIFF
--- a/4W/Gurdjieff-AAY-2.htm
+++ b/4W/Gurdjieff-AAY-2.htm
@@ -195,7 +195,7 @@ cellpadding="0">
 <p class="MsoBodyText2 c8">&nbsp;</p>
 <p class="MsoNormal"><b><span class='c4'>*3</span></b><span class=
 'c4'>&nbsp; «</span>Под маской помещался стол, за которым сидела
-секретарша холодной птичьей красоты<span class='c9'>» (<a href="/4W/texts/Pelevin.htm">В. Пелевин</a>
+секретарша холодной птичьей красоты<span class='c9'>» (<a href="/texts/Pelevin.htm">В. Пелевин</a>
 1)</span></p>
 <p class="MsoNormal"><span class='c4'>&nbsp;</span></p>
 <p class="MsoNormal c3"><b><span class='c9'>*4</span></b>
@@ -216,7 +216,7 @@ cellpadding="0">
 петухов&nbsp; и жаб...&nbsp; - Еще бывают пауки, мухи и&nbsp;
 летучие&nbsp; мыши,&nbsp; -&nbsp; сказал&nbsp; остановившийся рядом
 Иван Сергеевич.&nbsp; - Верно. А еще - обезьяны, кролики и
-козлы<span class='c4'>…» (<a href="/4W/texts/Pelevin.htm">В. Пелевин</a>
+козлы<span class='c4'>…» (<a href="/texts/Pelevin.htm">В. Пелевин</a>
 2)</span></p>
 <p class="MsoNormal"><span class='c4'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c4'>*7</span></b><span class=
@@ -244,13 +244,13 @@ cellpadding="0">
 представляет собой, в</p>
 <p class="MsoNormal c3">смысле границ своего понимания,
 геометрическую фигуру, - «куб», «квадрат» или</p>
-<p class="MsoNormal c3">«зигзаг».<span class='c4'>..» (<i><a href="/4W/texts/Miscellanea.htm">Гюрджиев</a>
+<p class="MsoNormal c3">«зигзаг».<span class='c4'>..» (<i><a href="/texts/Miscellanea.htm">Гюрджиев</a>
 6</i>)</span></p>
 <p class="MsoNormal c3"><span class='c9'>&nbsp;&nbsp; О
 классификации Гюрджиевым типов людей («идиотов») по различным
-характеристикам, включая геометрическим, см. <i><a href="/4W/texts/Miscellanea.htm">Риордан</a> 7,
-<a href="/4W/texts/Miscellanea.htm">Беннетт</a> 8,
-<a href="/4W/texts/Miscellanea.htm">Нотт</a>
+характеристикам, включая геометрическим, см. <i><a href="/texts/Miscellanea.htm">Риордан</a> 7,
+<a href="/texts/Miscellanea.htm">Беннетт</a> 8,
+<a href="/texts/Miscellanea.htm">Нотт</a>
 9</i>.</span></p>
 <p class="MsoNormal c3"><span class='c2'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c4'>*10</span></b><span class=
@@ -270,7 +270,7 @@ cellpadding="0">
 конца в другой, и я увидел буквально десятки существ геометрической
 формы. Моя способность видеть их была крайне неустойчива. Я на
 мгновение видел их, а затем терял их из виду и сталкивался с
-обычными людьми</span><span class='c14'>...» (<i><a href="/4W/texts/Miscellanea.htm">Кастанеда</a>
+обычными людьми</span><span class='c14'>...» (<i><a href="/texts/Miscellanea.htm">Кастанеда</a>
 10</i>)</span></p>
 <p class="MsoNormal">&nbsp;</p>
 <p class="MsoNormal"><b><span class='c4'>*11</span></b><span class=

--- a/4W/Gurdjieff-ABM-2.htm
+++ b/4W/Gurdjieff-ABM-2.htm
@@ -171,7 +171,7 @@ cellpadding="0" width="637">
 <p class="MsoNormal c5"><span class='c4'>&nbsp;</span></p>
 <p class="MsoNormal c5"><b class="c13"><span class=
 'c12'>Приложение:&nbsp;</span></b> <b class="c13"><span class=
-'c15'><a href="/4W/texts/Tantra.htm"><span 
+'c15'><a href="/texts/Tantra.htm"><span 
 class='c14'>Тантра</span></a></span></b></p>
 <p class="MsoNormal"><script type="text/javascript">
 //<![CDATA[

--- a/4W/Gurdjieff-ADA-2.htm
+++ b/4W/Gurdjieff-ADA-2.htm
@@ -146,7 +146,7 @@ cellpadding="0" width="619">
 'c12'>&nbsp; См. об этом у Идриса Шаха</span></p>
 <p class="MsoNormal"><span class='c7'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c7'>*8</span></b><span class=
-'c7'>&nbsp; <a href="/4W/texts/Wilder.htm">Торнтон
+'c7'>&nbsp; <a href="/texts/Wilder.htm">Торнтон
 Уайлдер</a></span></p>
 <p class="MsoNormal"><span class='c7'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c7'>*9</span></b><span class=
@@ -154,7 +154,7 @@ cellpadding="0" width="619">
 учителе, равви Ицекеле из Люблина: когда приходил к нему хасид
 первый раз, он вынимал <span class='c10'>из него душу, очищал ее от
 всякой ржавчины и всякого налета и возвращал обратно такой, какой
-она была в час рождения". (<i>Очищение душ</i>. <a href="/4W/texts/Hasidim.htm">«Хасидские
+она была в час рождения". (<i>Очищение душ</i>. <a href="/texts/Hasidim.htm">«Хасидские
 предания»</a> 1)</span></span></p>
 <p class="MsoNormal"><span class='c11'>&nbsp;</span></p>
 <h1><span class='c13'>*10</span><span class='c14'>&nbsp; Рабби
@@ -163,7 +163,7 @@ cellpadding="0" width="619">
 своего умершего учителя или учителя своего учителя. Только тогда
 звено соединяется со звеном, и учение течет от Моисея к Иисусу, от
 Иисуса к старейшинам [старцам], и так далее к собственному учителю
-цаддика, а от его учителя – к нему». (<i>Цепь</i>. <a href="/4W/texts/Hasidim.htm">«Хасидские
+цаддика, а от его учителя – к нему». (<i>Цепь</i>. <a href="/texts/Hasidim.htm">«Хасидские
 предания»</a> 2)</span></h1>
 <p class="MsoNormal c16"><span class='c15'>&nbsp;</span></p>
 </td>

--- a/4W/Gurdjieff-ADN.htm
+++ b/4W/Gurdjieff-ADN.htm
@@ -181,7 +181,7 @@ cellpadding="0">
 "Typewriter c16">============================</span></p>
 <p class="MsoNormal"><span class=
 "Typewriter c9">*1</span><span class="Typewriter c11">&nbsp;
-<a href="/4W/texts/Hasidim.htm">«Хасидские
+<a href="/texts/Hasidim.htm">«Хасидские
 предания»</a> 4</span></p>
 <p class="MsoNormal"><span class='c4'>&nbsp;</span></p>
 <p class="MsoNormal c15"><span class="Typewriter c17">Основной

--- a/4W/Gurdjieff-ADR-2.htm
+++ b/4W/Gurdjieff-ADR-2.htm
@@ -295,7 +295,7 @@ cellpadding="0">
 принцессы&nbsp; может&nbsp; только нарисованный человечек.&nbsp; -
 Почему? -&nbsp; Да&nbsp; потому, - сказал Итакин,&nbsp; - что
 принцесса тоже нарисована. Ну&nbsp; а нарисовано может быть все что
-угодно</span><span class='c13'>.» (<a href="/4W/texts/Pelevin.htm">Пелевин</a>
+угодно</span><span class='c13'>.» (<a href="/texts/Pelevin.htm">Пелевин</a>
 5)</span></p>
 <p class="MsoNormal"><span class='c11'>&nbsp;</span></p>
 <p class="MsoBodyText"><b><span class=

--- a/4W/Gurdjieff-ADZ-2.htm
+++ b/4W/Gurdjieff-ADZ-2.htm
@@ -203,7 +203,7 @@ Doctor, Alchemist and Christian Mystic». Мы обязаны Waite издани
 его же книгой «Предсказательное Таро», имеющей, в основном,
 довольно прикладной характер. Из русского наследия я очень ценю
 книги Владимира Шмакова. Также я люблю небольшую, но эмоциональную
-статью <a href="/4W/texts/Hermes.htm">«О
+статью <a href="/texts/Hermes.htm">«О
 Книге Гермеса»</a> академика Б. Л. Смирнова.</span></p>
 <p class="MsoNormal"><span class='c4'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c4'>*12</span></b><span class=

--- a/4W/Gurdjieff-AEO-2.htm
+++ b/4W/Gurdjieff-AEO-2.htm
@@ -207,7 +207,7 @@ men” (Цит. по книге: Idries Shah. “Caravan of Dreams”)</p>
 какого-то страха, часто затаенного. Искреннее самонаблюдение могло
 бы многое прояснить…</p>
 <p class="MsoBodyText2 c9">&nbsp;</p>
-<p class="MsoNormal"><b>*8</b>&nbsp; «Миттельшпиль». См. <a href="/4W/texts/Pelevin.htm">Пелевин</a> 4</p>
+<p class="MsoNormal"><b>*8</b>&nbsp; «Миттельшпиль». См. <a href="/texts/Pelevin.htm">Пелевин</a> 4</p>
 <p class="MsoNormal">&nbsp;</p>
 <p class="MsoNormal"><b>*9</b>&nbsp; <span class='c7'>«Ибо никто из
 нас не живет для себя и никто не умирает для себя, А живеи ли –
@@ -285,7 +285,7 @@ men” (Цит. по книге: Idries Shah. “Caravan of Dreams”)</p>
 <p class="MsoNormal"><span class='c7'>&nbsp;Как феникс из пламени,
 встал Андрогин.</span></p>
 <pre class="c11">
-<span class='c10'>(Николай Гумилев. <a href="/4W/texts/Gumilev.htm">Андрогин</a>)</span>
+<span class='c10'>(Николай Гумилев. <a href="/texts/Gumilev.htm">Андрогин</a>)</span>
 </pre>
 <p class="MsoNormal">&nbsp;</p>
 <pre class="c12">

--- a/4W/Gurdjieff-AEX.htm
+++ b/4W/Gurdjieff-AEX.htm
@@ -321,7 +321,7 @@ cellpadding="0" width="679">
 <p class="MsoNormal c3"><b>*1</b>&nbsp; См. сообщение <a href="Gurdjieff-ADL.htm">О боевых
 искусствах</a>.</p>
 <p class="MsoNormal c3"><b>*2</b> &nbsp;Buber, Martin. Tales of the
-Hasidim (<a href="/4W/texts/Hasidim.htm">«Хасидские
+Hasidim (<a href="/texts/Hasidim.htm">«Хасидские
 предания»</a> 3)</p>
 <p class="MsoNormal c3"><b>*3</b>&nbsp; Саша М.</p>
 <p class="MsoNormal c3"><span class='c13'>&nbsp;</span></p>

--- a/4W/Gurdjieff-AFA-2.htm
+++ b/4W/Gurdjieff-AFA-2.htm
@@ -102,7 +102,7 @@ cellpadding="0" width="679">
 3</i>)</p>
 <p class="MsoNormal c6">&nbsp;</p>
 <p class="MsoNormal c6"><b>*5</b>&nbsp; «Остальные совпадения
-случайны» (<i><a href="/4W/texts/Pelevin.htm">Пелевин</a>
+случайны» (<i><a href="/texts/Pelevin.htm">Пелевин</a>
 6)</i></p>
 <p class="MsoNormal c6">&nbsp;</p>
 <p class="MsoNormal c6"><b>*6</b>&nbsp; Арабско-французско-русское

--- a/4W/Gurdjieff-AFC-2.htm
+++ b/4W/Gurdjieff-AFC-2.htm
@@ -176,7 +176,7 @@ cellpadding="0" width="631">
 <p class="MsoBodyText c7"><b><span class=
 'c8'>*8</span></b><span class='c8'>&nbsp; Как не вспомнить название
 картины: «Пленные негуманоиды в штабе киевского военного округа»
-(<a href="/4W/texts/Pelevin.htm">В.
+(<a href="/texts/Pelevin.htm">В.
 Пелевин</a> 03). Да, нелегко было бы выбрать «сторону» в такой
 ситуации...</span></p>
 <p class="MsoBodyText c7"><span class='c8'>&nbsp;</span></p>

--- a/4W/Gurdjieff-AFP-2.htm
+++ b/4W/Gurdjieff-AFP-2.htm
@@ -277,11 +277,11 @@ cellpadding="0" width="625">
 <p class="MsoNormal"><span class='c8'>&nbsp;</span></p>
 <p class="MsoBodyText2 c9"><b><span class=
 'c8'>*17</span></b><span class='c8'>&nbsp; См. рассказ Пелевина
-«Водонапорная башня». (<a href="/4W/texts/Pelevin.htm">Пелевин</a> 9) Один
+«Водонапорная башня». (<a href="/texts/Pelevin.htm">Пелевин</a> 9) Один
 из лучших, по моему мнению...</span></p>
 <p class="MsoBodyText2 c9"><span class='c8'>&nbsp;</span></p>
 <p class="MsoBodyText2 c9"><b><span class=
-'c8'>*18</span></b><span class='c8'>&nbsp; См. <a href="/4W/texts/Pelevin.htm">Пелевин</a> 11.
+'c8'>*18</span></b><span class='c8'>&nbsp; См. <a href="/texts/Pelevin.htm">Пелевин</a> 11.
 «Что-то слышится родное...»</span></p>
 <p class="MsoBodyText2 c9"><span class='c8'>&nbsp;</span></p>
 <p class="MsoBodyText2 c9"><b><span class=
@@ -307,7 +307,7 @@ cellpadding="0" width="625">
 случаев это делается «подключением» ученика к Источнику.</p>
 <p class="MsoBodyText2 c10">&nbsp;</p>
 <p class="MsoBodyText2 c9"><b>*22&nbsp;</b> «Что нам стоит дом
-построить? Нарисуем – будем жить». <span class='c8'>См. <a href="/4W/texts/Pelevin.htm">Пелевин</a>
+построить? Нарисуем – будем жить». <span class='c8'>См. <a href="/texts/Pelevin.htm">Пелевин</a>
 5</span></p>
 <p class="MsoBodyText2 c10">&nbsp;</p>
 <p class="MsoBodyText2 c9"><b>*23</b>&nbsp; Таким образом

--- a/4W/Gurdjieff-AFV-1.htm
+++ b/4W/Gurdjieff-AFV-1.htm
@@ -419,7 +419,7 @@ cellpadding="0" width="631">
 <span class='c2'> </span>
 </pre>
 <pre>
-<span class='c2'>См. интересный <a href="/4W/texts/Ascension.htm">комментарий Б.Л. Смирнова</a></span>
+<span class='c2'>См. интересный <a href="/texts/Ascension.htm">комментарий Б.Л. Смирнова</a></span>
 </pre>
 <pre>
 <span class='c2'> </span>

--- a/4W/Gurdjieff-AFV-4.htm
+++ b/4W/Gurdjieff-AFV-4.htm
@@ -173,7 +173,7 @@ cellpadding="0" width="631">
 спас,</span></tt></p>
 <p class="MsoNormal"><tt><span class='c14'>Но выколол случайно
 глаз.</span></tt></p>
-<p class="MsoNormal c13"><span class='c15'><a href="/4W/texts/Miscellanea.htm">Восточная
+<p class="MsoNormal c13"><span class='c15'><a href="/texts/Miscellanea.htm">Восточная
 пословица</a> 4</span></p>
 <p class="MsoNormal c7"><span class='c2'>&nbsp;</span></p>
 <p class="MsoNormal"><span class='c2'>Неоднократно утверждалось и

--- a/4W/Gurdjieff-AFV-5.htm
+++ b/4W/Gurdjieff-AFV-5.htm
@@ -208,7 +208,7 @@ cellpadding="0" width="637">
 <pre>
 <span class=
 'c13'>велик, как сирруф. Но он этого не знает.»</span><span class=
-'c14'>  </span><span class='c11'>(<a href="/4W/texts/Pelevin.htm">Пелевин</a> 14)</span><span class='c14'> </span>
+'c14'>  </span><span class='c11'>(<a href="/texts/Pelevin.htm">Пелевин</a> 14)</span><span class='c14'> </span>
 </pre>
 <p class="MsoNormal c3"><span class='c9'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c9'>*6</span></b><span class=
@@ -229,7 +229,7 @@ cellpadding="0" width="637">
 рождаюсь»</p>
 <p class="MsoNormal"><span class=
 'c10'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-(<i><a href="/4W/texts/Miscellanea.htm">Бхагавад-Гита</a>
+(<i><a href="/texts/Miscellanea.htm">Бхагавад-Гита</a>
 2</i>).</span></p>
 <p class="MsoNormal"><span class='c10'>&nbsp;&nbsp; Обращает
 внимание акцент на <b>законе</b> [dharma.</span> «Дхарма ... –это
@@ -265,7 +265,7 @@ cellpadding="0" width="637">
 Но через долгое время утратилась эта йога.»</span></p>
 <p class="MsoNormal"><span class=
 'c10'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-(<i><a href="/4W/texts/Miscellanea.htm">Бхагавад-Гита</a>
+(<i><a href="/texts/Miscellanea.htm">Бхагавад-Гита</a>
 2</i>).</span></p>
 <p class="MsoNormal"><span class='c12'>[</span><span class=
 'c15'>ЙОГА – «<b>соединение</b>, сочетание, стягивание, средство»
@@ -573,7 +573,7 @@ machine</i>. Пользу из этого извлекают только «ме
 </pre>
 <p class="MsoNormal"><span class=
 'c10'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-(<i><a href="/4W/texts/Miscellanea.htm">Бхагавад-Гита</a>
+(<i><a href="/texts/Miscellanea.htm">Бхагавад-Гита</a>
 3</i>).</span></p>
 <p class="MsoNormal c3"><span class='c9'>&nbsp;</span></p>
 <pre>
@@ -880,7 +880,7 @@ Religions”</i>)</span></p>
 действует [на других] только своими знаниями. Прозорливость
 подтверждается [естественными законами]. Ведь давно уже известно,
 что знающему далеко до прозорливого.</span><span class='c11'>»
-(<i><a href="/4W/texts/Miscellanea.htm">Чжуанцзы</a>
+(<i><a href="/texts/Miscellanea.htm">Чжуанцзы</a>
 5)</i></span></p>
 <p class="MsoNormal c3"><span class='c9'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c9'>*53</span></b><span class=
@@ -920,7 +920,7 @@ Religions”</i>)</span></p>
 </pre>
 <p class="MsoNormal"><b><span class='c9'>*57</span></b><span class=
 'c19'>&nbsp; Не смог удержаться, чтобы не слямзить эту фразу у
-Пелевина! (<a href="/4W/texts/Pelevin.htm">Пелевин</a>
+Пелевина! (<a href="/texts/Pelevin.htm">Пелевин</a>
 6)</span></p>
 <pre class="c22">
 <span class='c5'> </span>
@@ -957,7 +957,7 @@ Religions”</i>)</span></p>
 </pre>
 <p class="MsoNormal c3"><span class='c9'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c9'>*60</span></b><span class=
-'c10'>&nbsp; <a href="/4W/texts/Hasidim.htm">«Хасидские
+'c10'>&nbsp; <a href="/texts/Hasidim.htm">«Хасидские
 предания»</a> 2</span></p>
 <p class="MsoNormal c3"><span class='c9'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c9'>*61</span></b><span class=
@@ -1136,7 +1136,7 @@ who?”</span></p>
 <b><span class='c5'>*71 </span></b><span class=
 'c11'> Ср.: </span><span class='c10'>"</span><span class=
 'c32'>The medium is the message</span><span class=
-'c10'>" <span class='c12'>(<a href="/4W/texts/Pelevin.htm">Пелевин</a> 13)</span><span class='c20'> </span></span>
+'c10'>" <span class='c12'>(<a href="/texts/Pelevin.htm">Пелевин</a> 13)</span><span class='c20'> </span></span>
 </pre>
 <p class="MsoNormal c3"><span class='c9'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c9'>*72</span></b><span class=

--- a/4W/Gurdjieff-AFV.htm
+++ b/4W/Gurdjieff-AFV.htm
@@ -674,7 +674,7 @@ IV. Место, время, люди</span></p>
 <span class='c18'>     - И третий - кто! </span>
 </pre>
 <pre>
-<span class='c18'>                        (<i><a href="/4W/texts/Pelevin.htm">Пелевин</a> 12</i>)</span>
+<span class='c18'>                        (<i><a href="/texts/Pelevin.htm">Пелевин</a> 12</i>)</span>
 </pre>
 <p class="MsoNormal"><span class='c2'>&nbsp;</span></p>
 <p class="MsoNormal"><span class='c2'>&nbsp;&nbsp; Принцип

--- a/4W/Gurdjieff-AGD-2.htm
+++ b/4W/Gurdjieff-AGD-2.htm
@@ -126,7 +126,7 @@ cellpadding="0" width="637">
 эзотеризма</a> Гл. V</span></p>
 <p class="MsoNormal"><span class='c6'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c6'>*8</span></b><span class=
-'c6'>&nbsp; См. ранний опус о <a href="/4W/texts/Moon.htm">Луне</a></span></p>
+'c6'>&nbsp; См. ранний опус о <a href="/texts/Moon.htm">Луне</a></span></p>
 <p class="MsoNormal"><span class='c6'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c6'>*9</span></b><span class=
 'c6'>&nbsp; См. Примечание «Латаиф» к книге Идриса Шаха <a href="http://www.sufism.ru/shah/sufi00.htm">«Суфии»</a></span></p>
@@ -145,7 +145,7 @@ cellpadding="0" width="637">
 нем сыграть.</span></p>
 <p class="MsoNormal"><span class=
 'c9'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span> <i><span class=
-'c7'><a href="/4W/texts/Rilke-Soz.htm">Р<span>.</span> М<span>.</span> Рильке<span>.</span>
+'c7'><a href="/texts/Rilke-Soz.htm">Р<span>.</span> М<span>.</span> Рильке<span>.</span>
 Созерцание</a></span></i></p>
 <p class="MsoNormal">&nbsp;</p>
 <p class="MsoNormal"><b><span class='c8'>*11</span></b><span class=

--- a/4W/Gurdjieff-AGO-4.htm
+++ b/4W/Gurdjieff-AGO-4.htm
@@ -123,7 +123,7 @@ cellpadding="0">
 85</i>.</span></p>
 <p class="MsoNormal"><span class='c6'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c9'>*04</span></b>
-<span class='c11'>&nbsp;</span><i><span class='c6'><a href="/4W/texts/Pelevin.htm">Пелевин</a>
+<span class='c11'>&nbsp;</span><i><span class='c6'><a href="/texts/Pelevin.htm">Пелевин</a>
 15</span></i></p>
 <p class="MsoNormal"><span class='c6'>&nbsp;</span></p>
 <p class="MsoNormal"><b><span class='c9'>*05</span></b>
@@ -172,7 +172,7 @@ cellpadding="0">
 </pre>
 <pre>
 <span class=
-'c13'>часть тех, кто на тебя  при  этом  смотрит,  ты  бы  умер  со  страху</span><span class='c14'>.</span><span class='c13'>»</span><span class='c15'> <i><a href="/4W/texts/Pelevin.htm">Пелевин</a> 16</i></span>
+'c13'>часть тех, кто на тебя  при  этом  смотрит,  ты  бы  умер  со  страху</span><span class='c14'>.</span><span class='c13'>»</span><span class='c15'> <i><a href="/texts/Pelevin.htm">Пелевин</a> 16</i></span>
 </pre>
 <pre>
 <span class='c6'> </span>

--- a/4W/Gurdjieff-AGZ.htm
+++ b/4W/Gurdjieff-AGZ.htm
@@ -268,7 +268,7 @@ cellpadding="0">
 Нас унижает наш успех.<br />
 Необычайность, небывалость<br />
 Зовет борцов совсем не тех.<br />
-(<i><a href="/4W/texts/Rilke-Soz.htm">Созерцание</a></i>)</span></p>
+(<i><a href="/texts/Rilke-Soz.htm">Созерцание</a></i>)</span></p>
 <p class="MsoNormal"><span class='c3'>&nbsp;</span></p>
 <p class="MsoNormal"><span class='c3'>&nbsp;&nbsp; А вот если бы мы
 захотели и постарались использовать форум в указанном выше аспекте,

--- a/4W/Kovenatsky.htm
+++ b/4W/Kovenatsky.htm
@@ -306,200 +306,200 @@ cellpadding="0" width="631">
 'c23'>&nbsp;&nbsp;&nbsp;&nbsp;</span></b> <b><span class=
 'c24'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></b><b><span class='c26'>&nbsp;<span class="c25">Литература</span></span></b></p>
 <p class="MsoNormal c2"><span class='c27'>&nbsp;</span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Boi-Toporami.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Boi-Toporami.htm"><span class='c12'>
 [Бой топорами]</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-%5bSamovosp%5d.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-%5bSamovosp%5d.htm"><span class='c12'>
 [Самовоспоминание]</span></a></span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Brat-Otkroy.htm"><span class='c12'>Брат,
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Brat-Otkroy.htm"><span class='c12'>Брат,
 открой! Свирепая метель...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Bylo-Vs.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Bylo-Vs.htm"><span class=
 'c12'>Было все кошмарно и сурово...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-V-Tihom.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-V-Tihom.htm"><span class=
 'c12'>В тихом омуте водятся черти...</span></a>”</span>
 <b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Videl-Ya.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Videl-Ya.htm"><span class=
 'c12'>Видел я немало лошадей...</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Vot-Opiat'.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Vot-Opiat'.htm"><span class=
 'c12'>Вот опять пришла весна…</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Vot-Prishla.htm"><span class='c12'>Вот
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Vot-Prishla.htm"><span class='c12'>Вот
 пришла весна опять...</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Gogen-O.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Gogen-O.htm"><span class=
 'c12'>Гоген открыл Таити...</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-DyadyaM.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-DyadyaM.htm"><span class=
 'c12'>Дядя Миша на гармони...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Zasvetilas'.htm"><span class='c12'>Засветилась
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Zasvetilas'.htm"><span class='c12'>Засветилась
 плешь на темени...</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Kak-Zolot.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Kak-Zolot.htm"><span class=
 'c12'>Как золотые липы хороши...</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Kogda-Za.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Kogda-Za.htm"><span class=
 'c12'>Когда заведут голоса непогоды...</span></a>”</span>
 <b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Kriahteli.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Kriahteli.htm"><span class=
 'c12'>Кряхтели и покашливали в зале...</span></a>”</span>
 <b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Mne-Nraviatsia.htm"><span class='c12'>Мне
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Mne-Nraviatsia.htm"><span class='c12'>Мне
 нравятся приемщики посуды...</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-My-Sideli.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-My-Sideli.htm"><span class=
 'c12'>Мы сидели в угрюмой каморке...</span></a>”</span>
 <b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Nebo-Osklizlo.htm"><span class='c12'>Небо
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Nebo-Osklizlo.htm"><span class='c12'>Небо
 осклизло...</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Neuyutno-T.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Neuyutno-T.htm"><span class=
 'c12'>Неуютно, тоскливо и гадко...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Otchego-B.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Otchego-B.htm"><span class=
 'c12'>Отчего бывает так, не знаю...</span></a>”</span>
 <b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Pogodite-Ya.htm"><span class='c12'>Погодите
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Pogodite-Ya.htm"><span class='c12'>Погодите
 – я еще приеду!..</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Sobralis'-Na.htm"><span class='c12'>Собрались
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Sobralis'-Na.htm"><span class='c12'>Собрались
 на поляне бандиты...</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Tleet-N.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Tleet-N.htm"><span class=
 'c12'>Тлеет небо, лужи, сырость...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Chernyie-M.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Chernyie-M.htm"><span class=
 'c12'>Черные мысли...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Eto-Bylo.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Eto-Bylo.htm"><span class=
 'c12'>Это было никем не замечено...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Ya-Krorodil.htm"><span class='c12'>Я
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Ya-Krorodil.htm"><span class='c12'>Я
 – крокодил в террариуме людном...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Ya-Vechnosti.htm"><span class='c12'>Я
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Ya-Vechnosti.htm"><span class='c12'>Я
 Вечности принадлежу,,,</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Ya-Nenavizhu.htm"><span class='c12'>Я
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Ya-Nenavizhu.htm"><span class='c12'>Я
 ненавижу слово <b>мы</b>...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Ya-Nochami.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Ya-Nochami.htm"><span class=
 'c12'>Я ночами летаю над городом…</span></a>”</span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Ya-Razlozhil.htm"><span class='c12'>Я
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Ya-Razlozhil.htm"><span class='c12'>Я
 разложил костер на пустыре...</span></a>”</span></p>
-<p class="MsoNormal"><span class='c10'>“<a href="/4W/texts/Kov-Ya-Ustal.htm"><span class=
+<p class="MsoNormal"><span class='c10'>“<a href="/texts/Kov-Ya-Ustal.htm"><span class=
 'c12'>Я устал марать бумагу...</span></a>”</span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Avtoportret.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Avtoportret.htm"><span class='c12'>
 Автопортрет</span></a></span> <b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Ballada-O.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Ballada-O.htm"><span class=
 'c12'>Баллада о сборщиках утиля</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Bezdna.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Bezdna.htm"><span class=
 'c12'>Бездна</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Brontozavr.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Brontozavr.htm"><span class=
 'c12'>Бронтозавр</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-V-Muzee.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-V-Muzee.htm"><span class=
 'c12'>В музее</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-V-Teatre.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-V-Teatre.htm"><span class=
 'c12'>В театре</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Vecher.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Vecher.htm"><span class=
 'c12'>Вечер на ипподроме</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Doroga-V.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Doroga-V.htm"><span class=
 'c12'>Дорога в Никуда</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Diadia.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Diadia.htm"><span class=
 'c12'>Дядя</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Diadia-Yasha.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Diadia-Yasha.htm"><span class='c12'>
 Дядя Яша Осташов</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Kamennaya.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Kamennaya.htm"><span class=
 'c12'>Каменная баба</span></a></span><b><span class=
 'c29'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Kolybel'naya.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Kolybel'naya.htm"><span class='c12'>
 Колыбельная</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Korol'-S.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Korol'-S.htm"><span class=
 'c12'>Король Сатурна</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Koshachiy-S.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Koshachiy-S.htm"><span class='c12'>
 Кошачий сонет</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Koshki.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Koshki.htm"><span class=
 'c12'>Кошки</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Leninskiy-V.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Leninskiy-V.htm"><span class='c12'>
 Ленинский вальс</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Lzhivaya-P.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Lzhivaya-P.htm"><span class=
 'c12'>Лживая птица</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Lihoborskoye.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Lihoborskoye.htm"><span class='c12'>
 Лихоборское детство</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Madonna.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Madonna.htm"><span class=
 'c12'>Мадонна</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Marsh-Tvorch.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Marsh-Tvorch.htm"><span class='c12'>
 Марш творческой интеллигенции</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Marsh-Shpionov.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Marsh-Shpionov.htm"><span class='c12'>
 Марш шпионов</span></a></span><b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Moi-Stihi.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Moi-Stihi.htm"><span class=
 'c12'>Мои стихи</span></a></span> <b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Monarhichesky.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Monarhichesky.htm"><span class='c12'>
 Монархический романс</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Nozh.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Nozh.htm"><span class=
 'c12'>Нож</span></a></span><b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Nochnaya.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Nochnaya.htm"><span class=
 'c12'>Ночная охота</span></a>&nbsp;</span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-O-Tvorchestve.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-O-Tvorchestve.htm"><span class='c12'>
 О творчестве</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Ob'iasnenie.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Ob'iasnenie.htm"><span class='c12'>
 Объяснение</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Olen'.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Olen'.htm"><span class=
 'c12'>Олень</span></a></span><b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Otchayanie.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Otchayanie.htm"><span class=
 'c12'>Отчаяние</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Ochered'.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Ochered'.htm"><span class=
 'c12'>Очередь</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Pamiati-M.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Pamiati-M.htm"><span class=
 'c12'>Памяти моей первой любви Л.А.К.</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Divan.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Divan.htm"><span class=
 'c12'>Песнь о диване</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Dva-Kretina.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Dva-Kretina.htm"><span class='c12'>
 Песня о чугунном шаре</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Pesnia-Pr.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Pesnia-Pr.htm"><span class=
 'c12'>Песня проституток</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Pesnia-O-Zh.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Pesnia-O-Zh.htm"><span class='c12'>
 Песня о желтой опасности</span></a><b class=
 "c30">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</b></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Pesnia-Yapon.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Pesnia-Yapon.htm"><span class='c12'>
 Песня о японских военопленных</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Peshchernye.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Peshchernye.htm"><span class='c12'>
 Пещерные люди</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Pingviny.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Pingviny.htm"><span class=
 'c12'>Пингвины</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Pro-Diadiu.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Pro-Diadiu.htm"><span class=
 'c12'>Про дядю Кешу</span></a></span><b><span class=
 'c31'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Prolog-Iz.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Prolog-Iz.htm"><span class=
 'c12'>Пролог из драмы-феерии «Начальник»</span></a></span>
 <b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Proshchaniye.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Proshchaniye.htm"><span class='c12'>
 Прощание</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Lilovy-K.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Lilovy-K.htm"><span class=
 'c12'>Романс о лиловом коне</span></a></span><b><span class=
 'c29'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Smert'-Ol.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Smert'-Ol.htm"><span class=
 'c12'>Смерть оленя</span></a></span><b><span class=
 'c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Smert'.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Smert'.htm"><span class=
 'c12'>Смерть старого мага</span></a></span><b><span class=
 'c29'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Son.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Son.htm"><span class=
 'c12'>Сон</span></a></span></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Tish'.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Tish'.htm"><span class=
 'c12'>Тишь</span></a></span><b><span class='c28'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Chelovek-S.htm"><span class=
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Chelovek-S.htm"><span class=
 'c12'>Человек с головой коня</span></a></span><b><span class=
 'c29'>+</span></b></p>
-<p class="MsoNormal"><span class='c10'><a href="/4W/texts/Kov-Shestviye-V.htm"><span class='c12'>
+<p class="MsoNormal"><span class='c10'><a href="/texts/Kov-Shestviye-V.htm"><span class='c12'>
 Шествие в красных колпаках</span></a></span></p>
 <p class="MsoNormal c2"><span class='c10'>&nbsp;</span></p>
 <p class="MsoNormal c20"><span class='c32'>&nbsp;</span></p>


### PR DESCRIPTION
Some of the links were broken, I hope that will fix it.

Apparently the /texts directory used to be referred as /4W/texts in the past.

The following mass-substitution command was applied to the repository:
    `find ./ -type f -name '*.htm*' -exec sed -i '' 's/\/4W\/texts/\/texts/g' '{}' \;`
This resulted in 116 substitutions.

Note: the `sed -i ''` is OSX-specific; `sed -i` should be used on Linux.